### PR TITLE
Set NODE_ENV to local for development and restrict test endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "nodemon src/index.ts",
+    "dev": "NODE_ENV=local nodemon src/index.ts",
     "build": "rimraf dist && tsc",
     "ts-check": "tsc --project tsconfig.json",
     "deploy:prod": "rimraf dist && tsc && vercel --prod",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,17 +12,20 @@ const PORT = env.PORT || 3000;
 
 const app: Application = express();
 
-app.get('/', async (req: Request, res: Response) => {
-  const message = await ask('Hello');
-  res.send(message);
-});
+// ローカルのみ有効
+if (process.env.NODE_ENV === 'local') {
+  app.get('/', async (req: Request, res: Response) => {
+    const message = await ask('Hello');
+    res.send(message);
+  });
 
-app.get('/image', async (req: Request, res: Response) => {
-  const prompt =
-    'a dog walking on the beach with sunglasses, portrait, ultra realistic, futuristic background , concept art, intricate details, highly detailed';
-  const imageUrl = await checkGenerateArt(prompt);
-  res.send(encodeURI(imageUrl));
-});
+  app.get('/image', async (req: Request, res: Response) => {
+    const prompt =
+      'a dog walking on the beach with sunglasses, portrait, ultra realistic, futuristic background , concept art, intricate details, highly detailed';
+    const imageUrl = await checkGenerateArt(prompt);
+    res.send(encodeURI(imageUrl));
+  });
+}
 
 app.post(
   '/webhook',


### PR DESCRIPTION
- Configure yarn dev to set NODE_ENV=local
- Wrap test endpoints (GET / and GET /image) in local environment check
- Prevent test endpoints from being exposed in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)